### PR TITLE
poly_bool_dart#6 Make epsilon configurable on Polygon operations

### DIFF
--- a/lib/polybool.dart
+++ b/lib/polybool.dart
@@ -1,4 +1,5 @@
 library polybool;
 
 export 'src/coordinate.dart';
+export 'src/epsilon.dart' show Epsilon;
 export 'src/polygon.dart';

--- a/lib/src/epsilon.dart
+++ b/lib/src/epsilon.dart
@@ -8,12 +8,12 @@ import 'dart:math' as math;
 import 'coordinate.dart';
 import 'types.dart';
 
-const epsilon = Epsilon();
+var epsilon = const Epsilon();
 
 class Epsilon {
-  static const eps = 1e-10; // sane default? sure why not
+  final double eps;
 
-  const Epsilon();
+  const Epsilon({this.eps = 1e-10});
 
   bool pointAboveOrOnLine(Coordinate pt, Coordinate left, Coordinate right) {
     final Ax = left.x;

--- a/lib/src/epsilon.dart
+++ b/lib/src/epsilon.dart
@@ -8,7 +8,7 @@ import 'dart:math' as math;
 import 'coordinate.dart';
 import 'types.dart';
 
-var epsilon = const Epsilon();
+Epsilon epsilon = const Epsilon();
 
 class Epsilon {
   final double eps;


### PR DESCRIPTION
🤖 Targets #6

Features/Fixes
- Change `Epsilon.eps` from `static const` to a `final double` field with a default of `1e-10`.