### PR TITLE
poly_bool_dart#6 Guard against zero-length segments in eventDivide

### DIFF
--- a/lib/src/intersector.dart
+++ b/lib/src/intersector.dart
@@ -52,6 +52,14 @@ class Intersecter {
   }
 
   EventNode eventDivide(EventNode ev, Coordinate pt) {
+    // Guard: skip division if pt coincides with either endpoint of the segment.
+    // Dividing at the start would make ev zero-length; dividing at the end
+    // would make the new segment (ns) zero-length. Both cause downstream errors.
+    if (epsilon.pointsSame(pt, ev.seg.start) ||
+        epsilon.pointsSame(pt, ev.seg.end)) {
+      return ev;
+    }
+
     final ns = segmentCopy(pt, ev.seg.end, ev.seg);
     eventUpdateEnd(ev, pt);
 


### PR DESCRIPTION
🤖 Closes #6

Features/Fixes
- Add a guard in `Intersecter.eventDivide` that skips division when the split point coincides (within epsilon) with either endpoint of the segment being divided.
- Dividing at the start would leave `ev` as a zero-length segment; dividing at the end would make the new segment `ns` zero-length. Both cases produce dangling end events with no status node, causing the `Zero-length segment detected` exception.